### PR TITLE
SwiftLog podspec

### DIFF
--- a/SwiftLog/1.1.0/Logging.podspec
+++ b/SwiftLog/1.1.0/Logging.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.license = { :type => 'Apache 2.0', :file => 'LICENSE.txt' }
   s.summary = 'A Logging API for Swift.'
   s.homepage = 'https://github.com/apple/swift-log'
-  s.author = 'Apple Inc.'
+  s.author = 'mayank.chaudhary@earnin.com'
   s.source = { :git => 'https://github.com/apple/swift-log.git', :tag => s.version.to_s }
   s.documentation_url = 'https://apple.github.io/swift-log'
   s.module_name = 'Logging'
@@ -12,8 +12,6 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.cocoapods_version = '>=1.6.0'
   s.ios.deployment_target = '8.0'
-  s.osx.deployment_target = '10.9'
-  s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
 
   s.source_files = 'Sources/Logging/**/*.swift'

--- a/SwiftLog/1.1.0/Logging.podspec
+++ b/SwiftLog/1.1.0/Logging.podspec
@@ -12,7 +12,6 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.cocoapods_version = '>=1.6.0'
   s.ios.deployment_target = '8.0'
-  s.watchos.deployment_target = '2.0'
 
   s.source_files = 'Sources/Logging/**/*.swift'
 end

--- a/SwiftLog/1.1.0/Logging.podspec
+++ b/SwiftLog/1.1.0/Logging.podspec
@@ -1,0 +1,20 @@
+Pod::Spec.new do |s|
+  s.name = 'Logging'
+  s.version = '1.1.0'
+  s.license = { :type => 'Apache 2.0', :file => 'LICENSE.txt' }
+  s.summary = 'A Logging API for Swift.'
+  s.homepage = 'https://github.com/apple/swift-log'
+  s.author = 'Apple Inc.'
+  s.source = { :git => 'https://github.com/apple/swift-log.git', :tag => s.version.to_s }
+  s.documentation_url = 'https://apple.github.io/swift-log'
+  s.module_name = 'Logging'
+
+  s.swift_version = '5.0'
+  s.cocoapods_version = '>=1.6.0'
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.9'
+  s.tvos.deployment_target = '9.0'
+  s.watchos.deployment_target = '2.0'
+
+  s.source_files = 'Sources/Logging/**/*.swift'
+end


### PR DESCRIPTION
Lint output results attached

[Logging.podspec.lint.output.txt](https://github.com/activehours/iOSSpecs/files/3377979/Logging.podspec.lint.output.txt)


```
Gowthams-MacBook-Pro:1.1.0 gowtham$ pod spec lint Logging.podspec

 -> Logging (1.1.0)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | xcodebuild:  note: Planning build
    - NOTE  | xcodebuild:  note: Constructing build description
    - NOTE  | xcodebuild:  warning: Capabilities for App may not function correctly because its entitlements use a placeholder team ID. To resolve this, select a development team in the build settings editor. (in target 'App')

Analyzed 1 podspec.

Logging.podspec passed validation.
```